### PR TITLE
GCD bug fix

### DIFF
--- a/repl-imports/gcd.fumola
+++ b/repl-imports/gcd.fumola
@@ -1,7 +1,7 @@
 module {
 #[listing]
 public func gcd(a : Nat, b : Nat) : Nat {
-  if (b == 1) { a } else {
+  if (b == 0) { a } else {
     gcd(b, a % b)
   }
 }


### PR DESCRIPTION
The basecase of `GCD` uses `0` not `1`.

Strangely, even with this buggy version, we still get some correct outputs: `gcd(x, 1)` and `gcd(1, y)` work for all `x` and `y`.

:1234: 